### PR TITLE
can now navigate via specific urls e.g /portfolio

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200
+  force = false


### PR DESCRIPTION
Create redirects when hosting on Netlify. (https://www.netlify.com/docs/redirects/).

[[redirects]] list in the netlify.toml config file at the root of the repository (project)

Put the netlify.toml in the root (/) directory of your project (repository) being deployed to Netlify. You can add the redirect lines to the end of the netlify.toml if it exists already.